### PR TITLE
fix: prevent duplicate service worker registration

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -49,24 +49,34 @@ function MainLayout() {
         refetchOnMount: 'always', // 컴포넌트 마운트 때마다 재요청
     });
 
+    const getMsUntilMidnight = () => {
+        const now = new Date();
+        const midnight = new Date();
+        midnight.setHours(24, 0, 0, 0);
+        return midnight.getTime() - now.getTime();
+    };
+
+    const today = new Date().toDateString();
+    const msUntilMidnight = getMsUntilMidnight();
+
     const {
         data: homeData,
         isLoading: homeLoading,
         isError: homeError,
     } = useQuery({
-        queryKey: ['home'],
+        queryKey: ['home', today],
         queryFn: fetchHomeData,
         enabled: !!isSessionValid, // 세션 유효할 때만
         // ── 신선도/캐시 보존 ──
-        staleTime: ONE_DAY, // 24시간 동안은 fresh
+        staleTime: msUntilMidnight, // 자정이 되면 stale 처리
         gcTime: ONE_DAY * 2, // 구독 끊겨도 캐시는 2일 보관(선택)
 
         // ── 자동 재조회(폴링) ──
-        refetchInterval: ONE_DAY, // 24시간마다 한 번 자동 재조회
+        refetchInterval: msUntilMidnight, // 자정에 맞춰 재조회
         refetchIntervalInBackground: true, // 백그라운드(비활성 탭)에서도 수행
 
         // ── 유저가 돌아왔을 때 ──
-        // 아래 옵션들은 "stale일 때"만 트리거 → 24시간 넘겨 stale이면 즉시 재조회
+        // 아래 옵션들은 "stale일 때"만 트리거 → 자정 이후 stale이면 즉시 재조회
         refetchOnMount: true,
         refetchOnWindowFocus: true,
         refetchOnReconnect: true,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -39,20 +39,8 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 );
 
 // --- 서비스 워커 등록 코드 시작 ---
-// 개발 환경에서는 서비스 워커가 빌드되지 않은 파일을 캐시하려 시도하여 오류가 발생할 수 있습니다.
-// 따라서, 프로덕션 빌드 (배포 시)에서만 서비스 워커를 등록하도록 조건을 추가하는 것이 좋습니다.
-if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
-        navigator.serviceWorker
-            .register('/service-worker.js')
-            .then((registration) => {
-                console.log('SW registered: ', registration);
-            })
-            .catch((registrationError) => {
-                console.log('SW registration failed: ', registrationError);
-            });
-    });
-}
+// Vite PWA 플러그인이 `registerSW.js`를 자동으로 삽입하여 서비스 워커를 등록합니다.
+// 중복 등록을 피하기 위해 별도의 수동 등록 코드를 제거했습니다.
 // --- 서비스 워커 등록 코드 끝 ---
 // --- 서비스 워커 등록 코드 추가 끝 ---
 // // router.tsx (또는 index.tsx, main.tsx 등 라우터를 정의한 파일)


### PR DESCRIPTION
## Summary
- remove manual service worker registration and rely on Vite PWA plugin

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d8e8e4e08325b5e27cd799bb5366