### PR TITLE
feat: persist FCM token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-// import { useEffect } from 'react';npm
+import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import './App.css';
 
@@ -11,31 +11,12 @@ import Detail from './pages/KnowledgeDetail/Detail';
 import KnowledgeListContainer from './pages/KnowledgeList/KnowledgeListContainer';
 import NotFound from './pages/NotFound/NotFound';
 import MainLayout from './layouts/MainLayout';
-// import { getFcmToken, PUSH_AVAILABLE } from './firebase';
+import { registerPushToken } from './firebase';
 
 function App() {
-    /* --------------------------------------------------
-     FCM 토큰 요청 → 로그 & 로컬저장 (첫 마운트 한 번)
-  -------------------------------------------------- */
-    // useEffect(() => {
-    //     let ignore = false;
-
-    //     (async () => {
-    //         console.log('▶ PUSH_AVAILABLE:', PUSH_AVAILABLE); // ① 브라우저 지원 여부
-    //         console.log('▶ Notification.permission:', Notification.permission); // ② 권한 상태
-
-    //         if (!PUSH_AVAILABLE) return;
-
-    //         const token = await getFcmToken();
-    //         console.log('▶ getFcmToken() 반환값:', token);
-
-    //         if (!ignore && token) {
-    //             console.log('[FCM] token:', token);
-    //         }
-    //     })();
-
-    //     return () => void (ignore = true);
-    // }, []);
+    useEffect(() => {
+        void registerPushToken();
+    }, []);
 
     return (
         <Routes>

--- a/src/pages/KnowledgeAdd/AddContainer.tsx
+++ b/src/pages/KnowledgeAdd/AddContainer.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import AddView from './components/AddView';
-import axiosInstance from '../../api/axios';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { getFcmToken, PUSH_AVAILABLE } from '../../firebase'; // ★ 새 래퍼 함수
+import axiosInstance from '../../api/axios';
+import { registerPushToken } from '../../firebase';
 
 export default function AddContainer() {
     const navigate = useNavigate();
@@ -14,28 +14,9 @@ export default function AddContainer() {
     const [content, setContent] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [charCount, setCharCount] = useState(0);
-    /* ----------------------------------------------------------
-     * 1) 푸시 토큰 발급 & 서버 저장
-     * -------------------------------------------------------- */
-    const registerPushToken = async () => {
-        if (!PUSH_AVAILABLE) return;
-
-        const token = await getFcmToken(); // ★ 권한 요청·SW 등록 포함
-        if (!token) {
-            console.warn('[FCM] 토큰을 발급받지 못했습니다.');
-            return;
-        }
-
-        try {
-            await axiosInstance.post('/token', { token });
-            console.debug('[FCM] 토큰 저장 완료');
-        } catch (e) {
-            console.error('[FCM] 토큰 저장 실패:', e);
-        }
-    };
     const getNonWhitespaceLength = (s: string) => s.replace(/\s/g, '').length;
     /* ----------------------------------------------------------
-     * 2) 게시글 전송
+     * 1) 게시글 전송
      * -------------------------------------------------------- */
     const handleSubmit = async () => {
         if (!title.trim() || !content.trim()) {


### PR DESCRIPTION
## 요약
- FCM 토큰을 localStorage에 저장하고 백엔드와 동기화
- 지식 등록을 올릴 때나 앱 시작 시 토큰 등록을 재사용

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac20001b708325b7180b3887628cb6