### PR TITLE
feat: improve FCM token sync for PWA

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 // src/App.tsx
-import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import './App.css';
 
@@ -11,12 +10,10 @@ import Detail from './pages/KnowledgeDetail/Detail';
 import KnowledgeListContainer from './pages/KnowledgeList/KnowledgeListContainer';
 import NotFound from './pages/NotFound/NotFound';
 import MainLayout from './layouts/MainLayout';
-import { registerPushToken } from './firebase';
+import useAutoSyncFcmToken from './hooks/useAutoSyncFcmToken';
 
 function App() {
-    useEffect(() => {
-        void registerPushToken();
-    }, []);
+    useAutoSyncFcmToken();
 
     return (
         <Routes>

--- a/src/hooks/useAutoSyncFcmToken.ts
+++ b/src/hooks/useAutoSyncFcmToken.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { registerPushToken, isStandalone, PUSH_AVAILABLE } from '../firebase';
+
+const NEXT_SYNC_KEY = 'fcmNextSyncAt';
+const MIN_COOLDOWN_MS = 1000 * 60 * 60 * 6; // 6 hours
+const MAX_COOLDOWN_MS = 1000 * 60 * 60 * 12; // 12 hours
+
+function scheduleNextSync(now: number) {
+  const delay = MIN_COOLDOWN_MS + Math.random() * (MAX_COOLDOWN_MS - MIN_COOLDOWN_MS);
+  localStorage.setItem(NEXT_SYNC_KEY, String(now + delay));
+}
+
+export default function useAutoSyncFcmToken() {
+  useEffect(() => {
+    if (!PUSH_AVAILABLE) return;
+    const isMobile = /iPhone|iPad|iPod|Android/.test(navigator.userAgent);
+
+    const sync = async () => {
+      if (Notification.permission !== 'granted') return;
+      if (isMobile && !isStandalone()) return;
+
+      const next = Number(localStorage.getItem(NEXT_SYNC_KEY) || '0');
+      const now = Date.now();
+      if (next && now < next) return;
+
+      await registerPushToken();
+      scheduleNextSync(now);
+    };
+
+    const visibilityHandler = () => {
+      if (!document.hidden) void sync();
+    };
+
+    void sync();
+    window.addEventListener('focus', sync);
+    document.addEventListener('visibilitychange', visibilityHandler);
+
+    return () => {
+      window.removeEventListener('focus', sync);
+      document.removeEventListener('visibilitychange', visibilityHandler);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- auto-sync FCM token on app focus with 6~12h cooldown
- request notification permission only from explicit user action
- cache and register push tokens after service worker is ready
- support token sync in both iOS and Android PWAs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad18d1b79c8325b1c9b49e97732c1f